### PR TITLE
remove visibility from constructor (build warning)

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -7,7 +7,7 @@ contract Migrations {
   address public owner;
   uint public last_completed_migration;
 
-  constructor() public {
+  constructor() {
     owner = msg.sender;
   }
 

--- a/contracts/oracles/ChainlinkedOracleMainAsset.sol
+++ b/contracts/oracles/ChainlinkedOracleMainAsset.sol
@@ -39,7 +39,6 @@ contract ChainlinkedOracleMainAsset is IOracleUsd, IOracleEth, Auth {
         address weth,
         address vaultParameters
     )
-        public
         Auth(vaultParameters)
     {
         require(tokenAddresses1.length == _usdAggregators.length, "Unit Protocol: ARGUMENTS_LENGTH_MISMATCH");

--- a/contracts/oracles/OraclePoolToken.sol
+++ b/contracts/oracles/OraclePoolToken.sol
@@ -25,7 +25,7 @@ contract OraclePoolToken is IOracleUsd {
 
     uint public immutable Q112 = 2 ** 112;
 
-    constructor(address _oracleRegistry) public {
+    constructor(address _oracleRegistry) {
         oracleRegistry = IOracleRegistry(_oracleRegistry);
         WETH = IOracleRegistry(_oracleRegistry).WETH();
     }

--- a/contracts/test-helpers/ChainlinkAggregator_Mock.sol
+++ b/contracts/test-helpers/ChainlinkAggregator_Mock.sol
@@ -14,7 +14,7 @@ contract ChainlinkAggregator_Mock {
 
     event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 timestamp);
 
-    constructor (int price, uint _decimals) public {
+    constructor (int price, uint _decimals) {
         latestAnswer = price;
         decimals = _decimals;
     }

--- a/contracts/test-helpers/ChainlinkOracleMainAsset_Mock.sol
+++ b/contracts/test-helpers/ChainlinkOracleMainAsset_Mock.sol
@@ -35,7 +35,6 @@ contract ChainlinkOracleMainAsset_Mock is ChainlinkedOracleSimple, Auth {
         address weth,
         address vaultParameters
     )
-    public
     Auth(vaultParameters)
     {
         require(tokenAddresses1.length == _usdAggregators.length, "Unit Protocol: ARGUMENTS_LENGTH_MISMATCH");

--- a/contracts/test-helpers/CyWETH.sol
+++ b/contracts/test-helpers/CyWETH.sol
@@ -28,7 +28,7 @@ contract CyWETH is EmptyToken {
         _totalSupply,
         msg.sender
     )
-    public {
+    {
       underlying = _underlying;
       implementation = _implementation;
       exchangeRateStoredInternal = _exchangeRateStoredInternal;

--- a/contracts/test-helpers/DummyToken.sol
+++ b/contracts/test-helpers/DummyToken.sol
@@ -22,5 +22,5 @@ contract DummyToken is EmptyToken {
         _totalSupply,
         msg.sender
     )
-    public {}
+    {}
 }

--- a/contracts/test-helpers/EmptyToken.sol
+++ b/contracts/test-helpers/EmptyToken.sol
@@ -197,7 +197,6 @@ contract EmptyToken is StandardToken {
         uint          _totalSupply,
         address       _firstHolder
     )
-    public
     {
         require(_firstHolder != address(0), "ZERO_ADDRESS");
         checkSymbolAndName(_symbol,_name);

--- a/contracts/test-helpers/Keep3rOracleMainAsset_Mock.sol
+++ b/contracts/test-helpers/Keep3rOracleMainAsset_Mock.sol
@@ -31,7 +31,6 @@ contract Keep3rOracleMainAsset_Mock is ChainlinkedOracleSimple {
         address weth,
         IAggregator chainlinkAggregator
     )
-        public
     {
         require(address(uniFactory) != address(0), "Unit Protocol: ZERO_ADDRESS");
         require(weth != address(0), "Unit Protocol: ZERO_ADDRESS");

--- a/contracts/test-helpers/KeydonixOracleMainAsset_Mock.sol
+++ b/contracts/test-helpers/KeydonixOracleMainAsset_Mock.sol
@@ -30,7 +30,6 @@ contract KeydonixOracleMainAsset_Mock is ChainlinkedKeydonixOracleMainAssetAbstr
         address weth,
         IAggregator chainlinkAggregator
     )
-        public
     {
         require(address(uniFactory) != address(0), "Unit Protocol: ZERO_ADDRESS");
         require(weth != address(0), "Unit Protocol: ZERO_ADDRESS");

--- a/contracts/test-helpers/KeydonixOraclePoolToken_Mock.sol
+++ b/contracts/test-helpers/KeydonixOraclePoolToken_Mock.sol
@@ -18,7 +18,7 @@ import "../helpers/SafeMath.sol";
 contract KeydonixOraclePoolToken_Mock is ChainlinkedKeydonixOraclePoolTokenAbstract {
     using SafeMath for uint;
 
-    constructor(address _keydonixOracleMainAsset_Mock) public {
+    constructor(address _keydonixOracleMainAsset_Mock) {
         uniswapOracleMainAsset = ChainlinkedKeydonixOracleMainAssetAbstract(_keydonixOracleMainAsset_Mock);
     }
 

--- a/contracts/test-helpers/UniswapV2Router02.sol
+++ b/contracts/test-helpers/UniswapV2Router02.sol
@@ -24,7 +24,7 @@ contract UniswapV2Router02 {
         _;
     }
 
-    constructor(address _factory, address payable _WETH) public {
+    constructor(address _factory, address payable _WETH) {
         factory = _factory;
         weth = _WETH;
     }


### PR DESCRIPTION
Similar to #31 this reduces build warnings even further by removing `public` from the `constructor`.